### PR TITLE
Add image positioning config, padding config, added NamedRoute example for exit / skip

### DIFF
--- a/flutter_onboard/README.md
+++ b/flutter_onboard/README.md
@@ -184,18 +184,24 @@ final List<OnBoardModel> onBoardData = [
     title: "Set your own goals and get better",
     description: "Goal support your motivation and inspire you to work harder",
     imgUrl: "assets/images/weight.png",
+    imgAlign: "middle", //top,middle,bottom
+    paddingConfig: {"title": 0, "description": 0, "img": 30}),  
   ),
   OnBoardModel(
     title: "Track your progress with statistics",
     description:
         "Analyse personal result with detailed chart and numerical values",
     imgUrl: 'assets/images/graph.png',
+    imgAlign: "top",
+    paddingConfig: {"title": 0, "description": 0, "img": 30}),
   ),
   OnBoardModel(
     title: "Create photo comparisons and share your results",
     description:
         "Take before and after photos to visualize progress and get the shape that you dream about",
     imgUrl: 'assets/images/phone.png',
+    imgAlign: "bottom", 
+    paddingConfig: {"title": 0, "description": 0, "img": 30}),
   ),
 ];
 

--- a/flutter_onboard/example/lib/main.dart
+++ b/flutter_onboard/example/lib/main.dart
@@ -108,17 +108,25 @@ final List<OnBoardModel> onBoardData = [
     title: "Set your own goals and get better",
     description: "Goal support your motivation and inspire you to work harder",
     imgUrl: "assets/images/weight.png",
+    imgAlign: "top", //top,middle,bottom
+    paddingConfig: {"title": 30, "description": 0, "img": 30}),
   ),
   OnBoardModel(
     title: "Track your progress with statistics",
     description:
         "Analyse personal result with detailed chart and numerical values",
     imgUrl: 'assets/images/graph.png',
+    imgAlign: "middle", //top,middle,bottom
+    paddingConfig: {"title": 0, "description": 0, "img": 30}),
   ),
   OnBoardModel(
     title: "Create photo comparissions and share your results",
     description:
         "Take before and after photos to visualize progress and get the shape that you dream about",
     imgUrl: 'assets/images/phone.png',
+    imgAlign: "bottom", //top,middle,bottom
+    paddingConfig: {"title": 30, "description": 0, "img": 30}),
   ),
 ];
+
+

--- a/flutter_onboard/example/lib/main.dart
+++ b/flutter_onboard/example/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:html';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_onboard/flutter_onboard.dart';
 import 'package:provider/provider.dart';
@@ -87,7 +89,7 @@ class HomeScreen extends StatelessWidget {
     );
   }
 
-  void _onNextTap(OnBoardState onBoardState) {
+  void _onNextTap(OnBoardState onBoardState, context) {
     if (!onBoardState.isLastPage) {
       _pageController.animateToPage(
         onBoardState.page + 1,
@@ -96,6 +98,7 @@ class HomeScreen extends StatelessWidget {
       );
     } else {
       print("done");
+      Navigator.pushNamed(context, '/namedroute01');
     }
   }
 }

--- a/flutter_onboard/lib/src/models/onboard_model.dart
+++ b/flutter_onboard/lib/src/models/onboard_model.dart
@@ -4,10 +4,15 @@ class OnBoardModel {
   final String title;
   final String description;
   final String imgUrl;
+  final String imgAlign;
+  final Map paddingConfig;
 
-  const OnBoardModel({
-    @required this.title,
-    @required this.description,
-    @required this.imgUrl,
-  });
+  const OnBoardModel(
+      {@required this.title,
+      @required this.description,
+      @required this.imgUrl,
+      @required this.imgAlign,
+      this.paddingConfig,
+      }
+      );
 }

--- a/flutter_onboard/lib/src/models/onboard_model.dart
+++ b/flutter_onboard/lib/src/models/onboard_model.dart
@@ -4,15 +4,16 @@ class OnBoardModel {
   final String title;
   final String description;
   final String imgUrl;
-  final String imgAlign;
-  final Map paddingConfig;
+  final String imgAlign = "middle";
+  final Map paddingConfig = {
+    {"title": 0.0, "description": 0.0, "img": 0.0}
+  };
 
-  const OnBoardModel(
-      {@required this.title,
-      @required this.description,
-      @required this.imgUrl,
-      @required this.imgAlign,
-      this.paddingConfig,
-      }
-      );
+  const OnBoardModel({
+    @required this.title,
+    @required this.description,
+    @required this.imgUrl,
+    @required this.imgAlign,
+    this.paddingConfig,
+  });
 }

--- a/flutter_onboard/lib/src/models/onboard_model.dart
+++ b/flutter_onboard/lib/src/models/onboard_model.dart
@@ -4,16 +4,15 @@ class OnBoardModel {
   final String title;
   final String description;
   final String imgUrl;
-  final String imgAlign = "middle";
-  final Map paddingConfig = {
-    {"title": 0.0, "description": 0.0, "img": 0.0}
-  };
+  final String imgAlign;
+  final Map paddingConfig;
 
-  const OnBoardModel({
-    @required this.title,
-    @required this.description,
-    @required this.imgUrl,
-    @required this.imgAlign,
-    this.paddingConfig,
-  });
+  const OnBoardModel(
+      {@required this.title,
+      @required this.description,
+      @required this.imgUrl,
+      @required this.imgAlign,
+      this.paddingConfig,
+      }
+      );
 }

--- a/flutter_onboard/lib/src/widgets/onboard.dart
+++ b/flutter_onboard/lib/src/widgets/onboard.dart
@@ -302,7 +302,7 @@ class onboardImage extends StatelessWidget {
     this.imgUrl,
     this.imageWidth,
     this.imageHeight,
-    this.padding,
+    this.padding: 0,
   });
 
   final String imgUrl;
@@ -334,7 +334,8 @@ class onboardTitle extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: titlepadding,
+      padding:
+          titlepadding != 0 ? EdgeInsets.all(titlepadding) : EdgeInsets.all(0),
       margin: const EdgeInsets.symmetric(horizontal: 12),
       child: Text(
         title,
@@ -361,7 +362,8 @@ class onboardDescription extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: descpadding != 0 ? descpadding : EdgeInsets.all(descpadding),
+      padding:
+          descpadding != 0 ? EdgeInsets.all(descpadding) : EdgeInsets.all(0),
       margin: const EdgeInsets.symmetric(horizontal: 12),
       child: Text(
         description,

--- a/flutter_onboard/lib/src/widgets/onboard.dart
+++ b/flutter_onboard/lib/src/widgets/onboard.dart
@@ -115,75 +115,56 @@ class OnBoard extends StatelessWidget {
                         state.onPageChanged(page, onBoardData.length),
                     itemCount: onBoardData.length,
                     itemBuilder: (BuildContext context, int index) {
-                      final image_section = onboardImage(
+                      onboardImage image_section = onboardImage(
                           imgUrl: onBoardData[index].imgUrl,
-                          padding: onBoardData[index].paddingConfig["img"]
-                              ? onBoardData[index].paddingConfig["img"]
-                              : 0,
+                          padding:
+                              30.0, //onBoardData[index].paddingConfig["img"],
                           imageWidth: imageWidth,
                           imageHeight: imageWidth);
 
-                      final title_section = onboardTitle(
+                      onboardTitle title_section = onboardTitle(
                           title: onBoardData[index].title,
-                          titlepadding:
-                              onBoardData[index].paddingConfig["title"],
+                          //titlepadding: 20.0,
+                          //onBoardData[index].paddingConfig["title"],
                           titleStyles: titleStyles);
-                      final description_section = onboardDescription(
+                      onboardDescription description_section =
+                          onboardDescription(
                         description: onBoardData[index].description,
-                        descpadding: onBoardData[index]
-                                .paddingConfig["description"]
-                            ? onBoardData[index].paddingConfig["description"]
-                            : 0,
+                        descpadding:
+                            0.0, //onBoardData[index].paddingConfig["description"],
                         descriptionStyles: descriptionStyles,
                       );
 
-                      List layoutList = [
-                        image_section,
-                        title_section,
-                        description_section
-                      ];
-                      switch (onBoardData[index].imgAlign) {
-                        case "top":
-                          {
-                            List layoutList = [
-                              image_section,
-                              title_section,
-                              description_section
-                            ];
-                          }
-                          break;
-
-                        case "middle":
-                          {
-                            List layoutList = [
-                              title_section,
-                              image_section,
-                              description_section
-                            ];
-                          }
-                          break;
-
-                        case "bottom":
-                          {
-                            List layoutList = [
-                              title_section,
-                              description_section,
-                              image_section
-                            ];
-                          }
-                          break;
-
-                        default:
-                          {
-                            List layoutList = [
-                              image_section,
-                              title_section,
-                              description_section
-                            ]; //statements;
-                          }
-                          break;
+                      print(onBoardData[index].imgAlign);
+                      List layoutList = [];
+                      if (onBoardData[index].imgAlign == "top") {
+                        layoutList = [
+                          image_section,
+                          title_section,
+                          description_section
+                        ];
+                      } else if (onBoardData[index].imgAlign == "middle") {
+                        layoutList = [
+                          title_section,
+                          image_section,
+                          description_section
+                        ];
+                      } else if (onBoardData[index].imgAlign == "bottom") {
+                        layoutList = [
+                          title_section,
+                          description_section,
+                          image_section
+                        ];
+                      } else {
+                        // print("else triggered");
+                        layoutList = [
+                          title_section,
+                          description_section,
+                          image_section
+                        ];
                       }
 
+                      // print(layoutList);
                       return Container(
                         child: Column(
                           children: <Widget>[
@@ -302,7 +283,7 @@ class onboardImage extends StatelessWidget {
     this.imgUrl,
     this.imageWidth,
     this.imageHeight,
-    this.padding: 0,
+    this.padding: 0.0,
   });
 
   final String imgUrl;
@@ -325,7 +306,7 @@ class onboardImage extends StatelessWidget {
 }
 
 class onboardTitle extends StatelessWidget {
-  onboardTitle({this.title: "", this.titlepadding: 0, this.titleStyles});
+  onboardTitle({this.title: "", this.titlepadding: 0.0, this.titleStyles});
 
   final String title;
   final double titlepadding;
@@ -334,8 +315,9 @@ class onboardTitle extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding:
-          titlepadding != 0 ? EdgeInsets.all(titlepadding) : EdgeInsets.all(0),
+      padding: titlepadding != 0.0
+          ? EdgeInsets.all(titlepadding)
+          : EdgeInsets.all(0),
       margin: const EdgeInsets.symmetric(horizontal: 12),
       child: Text(
         title,

--- a/flutter_onboard/lib/src/widgets/onboard.dart
+++ b/flutter_onboard/lib/src/widgets/onboard.dart
@@ -119,12 +119,10 @@ class OnBoard extends StatelessWidget {
                         child: Column(
                           children: <Widget>[
                             onboardTitle(
-                              imgUrl : onBoardData[index].imgUrl,
-                              padding: 30,
-                              imageWidth: imageWidth,
-                              imageHeight: imageWidth
-
-                            ),
+                                imgUrl: onBoardData[index].imgUrl,
+                                padding: 30,
+                                imageWidth: imageWidth,
+                                imageHeight: imageWidth),
                             // Container(
                             //   child: Image.asset(
                             //     onBoardData[index].imgUrl,
@@ -228,10 +226,9 @@ class OnBoard extends StatelessWidget {
   }
 }
 
-
 class onboardTitle extends StatelessWidget {
   // a stateless widget for the image in the onboarding flow
-  onboardTitle({ 
+  onboardTitle({
     this.imgUrl,
     this.imageWidth,
     this.imageHeight,
@@ -242,7 +239,6 @@ class onboardTitle extends StatelessWidget {
   final double imageWidth;
   final double imageHeight;
   final double padding;
-  
 
   @override
   Widget build(BuildContext context) {
@@ -253,8 +249,7 @@ class onboardTitle extends StatelessWidget {
         width: imageWidth,
         height: imageHeight,
         fit: BoxFit.contain,
-
       ),
     );
-  };
+  }
 }

--- a/flutter_onboard/lib/src/widgets/onboard.dart
+++ b/flutter_onboard/lib/src/widgets/onboard.dart
@@ -117,8 +117,7 @@ class OnBoard extends StatelessWidget {
                     itemBuilder: (BuildContext context, int index) {
                       onboardImage image_section = onboardImage(
                           imgUrl: onBoardData[index].imgUrl,
-                          padding:
-                              30.0, //onBoardData[index].paddingConfig["img"],
+                          padding: onBoardData[index].paddingConfig["img"],
                           imageWidth: imageWidth,
                           imageHeight: imageWidth);
 
@@ -283,7 +282,7 @@ class onboardImage extends StatelessWidget {
     this.imgUrl,
     this.imageWidth,
     this.imageHeight,
-    this.padding: 0.0,
+    this.padding = 0.0,
   });
 
   final String imgUrl;

--- a/flutter_onboard/lib/src/widgets/onboard.dart
+++ b/flutter_onboard/lib/src/widgets/onboard.dart
@@ -342,8 +342,7 @@ class onboardDescription extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding:
-          descpadding != 0 ? descpadding : const EdgeInsets.all(descpadding),
+      padding: descpadding != 0 ? descpadding : EdgeInsets.all(descpadding),
       margin: const EdgeInsets.symmetric(horizontal: 12),
       child: Text(
         description,

--- a/flutter_onboard/lib/src/widgets/onboard.dart
+++ b/flutter_onboard/lib/src/widgets/onboard.dart
@@ -241,7 +241,7 @@ class onboardTitle extends StatelessWidget {
   final String imgUrl;
   final double imageWidth;
   final double imageHeight;
-  final int padding;
+  final double padding;
   
 
   @override

--- a/flutter_onboard/lib/src/widgets/onboard.dart
+++ b/flutter_onboard/lib/src/widgets/onboard.dart
@@ -115,52 +115,106 @@ class OnBoard extends StatelessWidget {
                         state.onPageChanged(page, onBoardData.length),
                     itemCount: onBoardData.length,
                     itemBuilder: (BuildContext context, int index) {
+                      final image_section = onboardImage(
+                          imgUrl: onBoardData[index].imgUrl,
+                          padding: onBoardData[index].paddingConfig.img
+                              ? onBoardData[index].paddingConfig.img
+                              : 0,
+                          imageWidth: imageWidth,
+                          imageHeight: imageWidth);
+
+                      final title_section = onboardTitle();
+                      final description_section = onboardDescription();
+
+                      switch (onBoardData[index].imgAlign) {
+                        case "top":
+                          {
+                            List layoutList = [
+                              image_section,
+                              title_section,
+                              description_section
+                            ];
+                          }
+                          break;
+
+                        case "middle":
+                          {
+                            List layoutList = [
+                              title_section,
+                              image_section,
+                              description_section
+                            ];
+                          }
+                          break;
+
+                        case "bottom":
+                          {
+                            List layoutList = [
+                              title_section,
+                              description_section,
+                              image_section
+                            ];
+                          }
+                          break;
+
+                        default:
+                          {
+                            List layoutList = [
+                              image_section,
+                              title_section,
+                              description_section
+                            ]; //statements;
+                          }
+                          break;
+                      }
+
                       return Container(
                         child: Column(
                           children: <Widget>[
-                            onboardTitle(
-                                imgUrl: onBoardData[index].imgUrl,
-                                padding: 30,
-                                imageWidth: imageWidth,
-                                imageHeight: imageWidth),
-                            // Container(
-                            //   child: Image.asset(
-                            //     onBoardData[index].imgUrl,
-                            //     width: imageWidth,
-                            //     height: imageHeight,
-                            //     fit: BoxFit.contain,
-                            //   ),
-                            // ),
-                            Container(
-                              margin:
-                                  const EdgeInsets.symmetric(horizontal: 12),
-                              child: Text(
-                                onBoardData[index].title,
-                                textAlign: TextAlign.center,
-                                style: titleStyles != null
-                                    ? titleStyles
-                                    : const TextStyle(
-                                        fontSize: 18,
-                                        fontWeight: FontWeight.bold,
-                                      ),
-                              ),
-                            ),
-                            Container(
-                              padding: const EdgeInsets.symmetric(vertical: 12),
-                              margin:
-                                  const EdgeInsets.symmetric(horizontal: 12),
-                              child: Text(
-                                onBoardData[index].description,
-                                textAlign: TextAlign.center,
-                                style: descriptionStyles != null
-                                    ? descriptionStyles
-                                    : const TextStyle(
-                                        fontSize: 14,
-                                        color: Colors.black54,
-                                      ),
-                              ),
-                            ),
+                            layoutList[0],
+                            layoutList[1],
+                            layoutList[2]
                           ],
+                          //[
+                          //   // Container(
+                          //   //   child: Image.asset(
+                          //   //     onBoardData[index].imgUrl,
+                          //   //     width: imageWidth,
+                          //   //     height: imageHeight,
+                          //   //     fit: BoxFit.contain,
+                          //   //   ),
+                          //   // ),
+                          //   // Container(
+                          //   //   margin:
+                          //   //       const EdgeInsets.symmetric(horizontal: 12),
+                          //   //   child: Text(
+                          //   //     onBoardData[index].title,
+                          //   //     textAlign: TextAlign.center,
+                          //   //     style: titleStyles != null
+                          //   //         ? titleStyles
+                          //   //         : const TextStyle(
+                          //   //             fontSize: 18,
+                          //   //             fontWeight: FontWeight.bold,
+                          //   //           ),
+                          //   //   ),
+                          //   // ),
+
+                          //   Container(
+                          //     padding: const EdgeInsets.symmetric(vertical: 12),
+                          //     margin:
+                          //         const EdgeInsets.symmetric(horizontal: 12),
+                          //     child: Text(
+                          //       onBoardData[index].description,
+                          //       textAlign: TextAlign.center,
+                          //       style: descriptionStyles != null
+                          //           ? descriptionStyles
+                          //           : const TextStyle(
+                          //               fontSize: 14,
+                          //               color: Colors.black54,
+                          //             ),
+                          //     ),
+                          //   ),
+                          //],
                         ),
                       );
                     },
@@ -226,9 +280,9 @@ class OnBoard extends StatelessWidget {
   }
 }
 
-class onboardTitle extends StatelessWidget {
+class onboardImage extends StatelessWidget {
   // a stateless widget for the image in the onboarding flow
-  onboardTitle({
+  onboardImage({
     this.imgUrl,
     this.imageWidth,
     this.imageHeight,
@@ -249,6 +303,57 @@ class onboardTitle extends StatelessWidget {
         width: imageWidth,
         height: imageHeight,
         fit: BoxFit.contain,
+      ),
+    );
+  }
+}
+
+class onboardTitle extends StatelessWidget {
+  onboardTitle({this.title: "", this.titlepadding: 0});
+
+  final String title;
+  final double titlepadding;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: titlepadding,
+      margin: const EdgeInsets.symmetric(horizontal: 12),
+      child: Text(
+        title,
+        textAlign: TextAlign.center,
+        style: titleStyles != null
+            ? titleStyles
+            : const TextStyle(
+                fontSize: 18,
+                fontWeight: FontWeight.bold,
+              ),
+      ),
+    );
+  }
+}
+
+class onboardDescription extends StatelessWidget {
+  onboardDescription({this.description = "", this.descpadding = 0});
+
+  final String description;
+  final double descpadding;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding:
+          descpadding != 0 ? descpadding : const EdgeInsets.all(descpadding),
+      margin: const EdgeInsets.symmetric(horizontal: 12),
+      child: Text(
+        description,
+        textAlign: TextAlign.center,
+        style: descriptionStyles != null
+            ? descriptionStyles
+            : const TextStyle(
+                fontSize: 14,
+                color: Colors.black54,
+              ),
       ),
     );
   }

--- a/flutter_onboard/lib/src/widgets/onboard.dart
+++ b/flutter_onboard/lib/src/widgets/onboard.dart
@@ -117,20 +117,24 @@ class OnBoard extends StatelessWidget {
                     itemBuilder: (BuildContext context, int index) {
                       onboardImage image_section = onboardImage(
                           imgUrl: onBoardData[index].imgUrl,
-                          padding: onBoardData[index].paddingConfig["img"],
+                          padding: onBoardData[index]
+                              .paddingConfig["img"]
+                              .toDouble(),
                           imageWidth: imageWidth,
                           imageHeight: imageWidth);
 
                       onboardTitle title_section = onboardTitle(
                           title: onBoardData[index].title,
-                          //titlepadding: 20.0,
-                          //onBoardData[index].paddingConfig["title"],
+                          titlepadding: onBoardData[index]
+                              .paddingConfig["title"]
+                              .toDouble(),
                           titleStyles: titleStyles);
                       onboardDescription description_section =
                           onboardDescription(
                         description: onBoardData[index].description,
-                        descpadding:
-                            0.0, //onBoardData[index].paddingConfig["description"],
+                        descpadding: onBoardData[index]
+                            .paddingConfig["description"]
+                            .toDouble(),
                         descriptionStyles: descriptionStyles,
                       );
 
@@ -282,7 +286,7 @@ class onboardImage extends StatelessWidget {
     this.imgUrl,
     this.imageWidth,
     this.imageHeight,
-    this.padding = 0.0,
+    this.padding = 0,
   });
 
   final String imgUrl;
@@ -305,7 +309,7 @@ class onboardImage extends StatelessWidget {
 }
 
 class onboardTitle extends StatelessWidget {
-  onboardTitle({this.title: "", this.titlepadding: 0.0, this.titleStyles});
+  onboardTitle({this.title: "", this.titlepadding = 0.0, this.titleStyles});
 
   final String title;
   final double titlepadding;
@@ -314,9 +318,7 @@ class onboardTitle extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: titlepadding != 0.0
-          ? EdgeInsets.all(titlepadding)
-          : EdgeInsets.all(0),
+      padding: EdgeInsets.all(titlepadding),
       margin: const EdgeInsets.symmetric(horizontal: 12),
       child: Text(
         title,
@@ -334,7 +336,7 @@ class onboardTitle extends StatelessWidget {
 
 class onboardDescription extends StatelessWidget {
   onboardDescription(
-      {this.description = "", this.descpadding = 0, this.descriptionStyles});
+      {this.description = "", this.descpadding = 0.0, this.descriptionStyles});
 
   final String description;
   final double descpadding;
@@ -343,8 +345,7 @@ class onboardDescription extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding:
-          descpadding != 0 ? EdgeInsets.all(descpadding) : EdgeInsets.all(0),
+      padding: EdgeInsets.all(descpadding),
       margin: const EdgeInsets.symmetric(horizontal: 12),
       child: Text(
         description,

--- a/flutter_onboard/lib/src/widgets/onboard.dart
+++ b/flutter_onboard/lib/src/widgets/onboard.dart
@@ -117,15 +117,31 @@ class OnBoard extends StatelessWidget {
                     itemBuilder: (BuildContext context, int index) {
                       final image_section = onboardImage(
                           imgUrl: onBoardData[index].imgUrl,
-                          padding: onBoardData[index].paddingConfig.img
-                              ? onBoardData[index].paddingConfig.img
+                          padding: onBoardData[index].paddingConfig["img"]
+                              ? onBoardData[index].paddingConfig["img"]
                               : 0,
                           imageWidth: imageWidth,
                           imageHeight: imageWidth);
 
-                      final title_section = onboardTitle();
-                      final description_section = onboardDescription();
+                      final title_section = onboardTitle(
+                          title: onBoardData[index].title,
+                          titlepadding:
+                              onBoardData[index].paddingConfig["title"],
+                          titleStyles: titleStyles);
+                      final description_section = onboardDescription(
+                        description: onBoardData[index].description,
+                        descpadding: onBoardData[index]
+                                .paddingConfig["description"]
+                            ? onBoardData[index].paddingConfig["description"]
+                            : 0,
+                        descriptionStyles: descriptionStyles,
+                      );
 
+                      List layoutList = [
+                        image_section,
+                        title_section,
+                        description_section
+                      ];
                       switch (onBoardData[index].imgAlign) {
                         case "top":
                           {
@@ -309,10 +325,11 @@ class onboardImage extends StatelessWidget {
 }
 
 class onboardTitle extends StatelessWidget {
-  onboardTitle({this.title: "", this.titlepadding: 0});
+  onboardTitle({this.title: "", this.titlepadding: 0, this.titleStyles});
 
   final String title;
   final double titlepadding;
+  final TextStyle titleStyles;
 
   @override
   Widget build(BuildContext context) {
@@ -334,10 +351,12 @@ class onboardTitle extends StatelessWidget {
 }
 
 class onboardDescription extends StatelessWidget {
-  onboardDescription({this.description = "", this.descpadding = 0});
+  onboardDescription(
+      {this.description = "", this.descpadding = 0, this.descriptionStyles});
 
   final String description;
   final double descpadding;
+  final TextStyle descriptionStyles;
 
   @override
   Widget build(BuildContext context) {

--- a/flutter_onboard/lib/src/widgets/onboard.dart
+++ b/flutter_onboard/lib/src/widgets/onboard.dart
@@ -118,14 +118,21 @@ class OnBoard extends StatelessWidget {
                       return Container(
                         child: Column(
                           children: <Widget>[
-                            Container(
-                              child: Image.asset(
-                                onBoardData[index].imgUrl,
-                                width: imageWidth,
-                                height: imageHeight,
-                                fit: BoxFit.contain,
-                              ),
+                            onboardTitle(
+                              imgUrl : onBoardData[index].imgUrl,
+                              padding: 30,
+                              imageWidth: imageWidth,
+                              imageHeight: imageWidth
+
                             ),
+                            // Container(
+                            //   child: Image.asset(
+                            //     onBoardData[index].imgUrl,
+                            //     width: imageWidth,
+                            //     height: imageHeight,
+                            //     fit: BoxFit.contain,
+                            //   ),
+                            // ),
                             Container(
                               margin:
                                   const EdgeInsets.symmetric(horizontal: 12),
@@ -219,4 +226,35 @@ class OnBoard extends StatelessWidget {
       onDone();
     }
   }
+}
+
+
+class onboardTitle extends StatelessWidget {
+  // a stateless widget for the image in the onboarding flow
+  onboardTitle({ 
+    this.imgUrl,
+    this.imageWidth,
+    this.imageHeight,
+    this.padding,
+  });
+
+  final String imgUrl;
+  final double imageWidth;
+  final double imageHeight;
+  final int padding;
+  
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.all(padding),
+      child: Image.asset(
+        imgUrl,
+        width: imageWidth,
+        height: imageHeight,
+        fit: BoxFit.contain,
+
+      ),
+    );
+  };
 }

--- a/flutter_onboard/pubspec.yaml
+++ b/flutter_onboard/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_onboard
 description: A simple, elegant and easy to use onboard widget for both android and ios devices.
-version: 0.1.0
+version: 0.1.1
 homepage: https://github.com/mohanasundaramn/ms-flutter-packages
 repository: https://github.com/mohanasundaramn/ms-flutter-packages/tree/master/flutter_onboard
 


### PR DESCRIPTION
Hi there, 

I need to add tests around this, so no problem if you reject this request for now!
This PR adds/exposes:

- The ability to position the Image in the onboarding screen to either the `top`, `middle` or `bottom` position. 
- Unique padding properties for the title, description and image
- A Navigation example to a Named Route on done press. The `onDone()` function does not seem to be working so it's been attached to the buttons for now. 

Image positioning was something i wanted in a personal project. Hopefully it will help someone else out there!
This operates from the config map. If you don't include padding properties it it will just set all padding to 0.0 (title will revert to the padding you set)
Readme has been updated with the example map

